### PR TITLE
Grad handbook changes after AY18-19

### DIFF
--- a/ms.tex
+++ b/ms.tex
@@ -69,7 +69,8 @@ student must meet the requirements specified below:
 
 \item Complete a minimum of 12 credits in complementary coursework
   chosen in consultation with, and approved by, the student's academic
-  advisor.  (Note: the academic advisor for M.S. students is typically the CMSE Graduate Director.)
+  advisor.  (Note: the academic advisor for M.S. students is typically
+  the CMSE Graduate Director.) 
  
 \item All M.S. students must complete Responsible Conduct of Research (RCR)
   Training and submit annual reports as specified by the
@@ -87,7 +88,8 @@ original research on a problem in computational and/or data
 science. The student will enroll in a minimum of 4 and a maximum of 8
 credits of CMSE 899 (Master's Thesis Research). This thesis research
 will culminate in a written thesis to be submitted to, and accepted
-by, a guidance committee. 
+by, a guidance committee.   Note that the credits for CMSE 899 count
+toward the 30 total credits required for the degree.
 
 \vspace{3mm}
 \noindent
@@ -95,7 +97,17 @@ by, a guidance committee.
 apply. In lieu of pursuing original research in computational and/or
 data science, the student will enroll in additional coursework. This
 coursework may include up to 3 credits of CMSE 891 (Independent Study)
-if approved by the student's academic advisor. 
+if approved by the student's academic advisor.   Note that the credits
+for CMSE 891 count
+toward the 30 total credits required for the degree.
+
+\vspace{3mm}
+\noindent
+\textbf{Course level and grade requirements.}  Of the 30 credits
+required for the M.S. in CMSE, no more than 6 credits of can be at the
+400 level, and no credits at the 300 level or below may count toward
+the degree.  Furthermore, all courses counted toward the degree must
+have a minimum grade of 2.0.
 
 
 \subsubsection{Selection of thesis advisor}
@@ -164,7 +176,7 @@ will ensure that their thesis conforms to the
 \href{https://grad.msu.edu/etd/formatting-guide}{Graduate School
 Thesis Formatting Guide}.
 
-The guidance committee will provide writtennte feedback on the thesis within one
+The guidance committee will provide written feedback on the thesis within one
 week, and the student is expected to make any necessary revisions and
 get approval from their guidance committee in a timely manner.  After
 their guidance committee approves of the thesis, it must be submitted,

--- a/performance.tex
+++ b/performance.tex
@@ -15,7 +15,7 @@ performance.
 \subsection{Grades}
 
 \noindent \textbf{College Regulations:} A 3.0 cumulative grade point
-average (GPA) is a 3.0 average on coursesin the student's Program
+average (GPA) is a 3.0 average on courses in the student's Program
 Plan.  (Note that courses that have already been taken cannot be
 dropped from the Program Plan.)  Research credits are not considered
 in determining the GPA for either the University or College standard,

--- a/phd.tex
+++ b/phd.tex
@@ -64,7 +64,7 @@ Sections~\ref{sec:core_courses} and~\ref{sec:qual_exam} for more information.
   No more than 6 credits of this coursework can be below the 800 level
   (and all such coursework is allowable only with approval of the
   Graduate Director), and none of this coursework can be below the 400
-  level.  See Section~\ref{sec:cognate_course}.
+  level.  See Section~\ref{sec:cognate_course}.  
 
 \item Complete a minimum of 24, and maximum of 36, dissertation
   research credits (CMSE 999).
@@ -115,7 +115,9 @@ Students who demonstrate proficiency in this way are still required to
 meet the minimum course credit requirement for the degree (30 credits
 beyond the Bachelor's degree).  (The exception to this rule is
 students who enter the CMSE PhD program with prior graduate
-coursework; see Appendix~\ref{sec:prior_coursework}.)
+coursework; see Appendix~\ref{sec:prior_coursework}.)  Note that all courses
+counted toward the degree, including core courses, must
+have a minimum grade of 2.0.
 
 \vspace{3mm}
 \subsubsection{Qualifying examination}
@@ -199,8 +201,10 @@ committee), and must include at least 12 credits of
 coursework addressing a single general topic or subject area.  This
 cognate can be in any subject area, including an application area,
 mathematics, statistics, or computer science.  A minimum GPA of 3.0 is
-expected in the cognate area, and no more than 6 credits can be below
-the 800 level (with no credits below the 400 level).  Note that this
+expected in the cognate area, and no more than 6 credits can be at
+the 400 level (with no credits at the 300 level or below counting
+toward the cognate).  All courses counted toward the degree must
+have a minimum grade of 2.0.  Note that this
 credit requirement can be waived for students who enter the CMSE PhD
 program with prior graduate coursework; see
 Appendix~\ref{sec:prior_coursework}.

--- a/prior_grad_coursework.tex
+++ b/prior_grad_coursework.tex
@@ -1,4 +1,4 @@
-\section{Policy regarding students entering the CMSE PhD program with prior graduate coursework}
+\section{Policy regarding students entering the CMSE MS or PhD program with prior graduate coursework}
 \label{sec:prior_coursework}
 
 \vspace{4mm}
@@ -8,15 +8,18 @@ approved by the CMSE Graduate Studies Committee on May 1, 2017 and is
 valid for all CMSE PhD students, regardless of start date (i.e., it
 may be applied retroactively to students who started in the PhD
 program prior to May 1, 2017).  This policy does not apply to students
-pursuing a terminal Master's degree in CMSE, who must complete a
-minimum of 30 credits of graduate-level coursework to attain the
-degree.
+pursuing a Master's degree in CMSE (either as a terminal degree or as
+a part of their PhD), who must complete a
+minimum of 30 credits of graduate-level coursework \textbf{at MSU} to attain the
+degree.  Note, however, that this 30-credit limit for the Master's
+degree may include credits transferred from
+other institutions; see below for more information on this.
 
 \vspace{2mm}
 \noindent
 \textbf{Reason for this policy:} The CMSE graduate handbook states
-that “Students must take a minimum of 30 credit hours of
-non-research-based coursework beyond the Bachelor’s level.”  However,
+that ``Students must take a minimum of 30 credit hours of
+non-research-based coursework beyond the Bachelor’s level.''  However,
 some students enter the CMSE PhD program with substantial amounts of
 prior graduate-level coursework (which may include a M.S., PhD, or
 graduate coursework without a degree).  We wish to ensure that
@@ -60,14 +63,46 @@ take a minimum of 6 credits of coursework beyond the core courses.
 
 \vspace{2mm}
 \noindent
-\textbf{30 credit requirement:} The requirement of a minimum of 30
+\textbf{30 credit requirement (PhD program):} The requirement of a minimum of 30
 credits of coursework while enrolled in the CMSE PhD program may be
-waived by the Graduate Director, in consultation with the student’s
+waived by the Graduate Director, in consultation with the student's
 dissertation advisor and dissertation committee.  The overall
-guideline for the total amount of coursework is that the student’s
+guideline for the total amount of coursework is that the student's
 relevant prior graduate coursework, plus courses taken while in the
 CMSE PhD program, should meet or exceed the equivalent of 30 credits
-of graduate-level coursework at MSU.
+of graduate-level coursework at MSU. 
+
+\vspace{2mm}
+\noindent
+\textbf{30 credit requirement (M.S. program):}  The requirement of a
+minimum of 30 credits of coursework (including CMSE 899 and/or 891,
+depending on whether a student is pursuing a Plan A or Plan B M.S.)
+cannot be waived, as it is a university requirement.  This includes
+both terminal Master's degrees as well as those pursued during the
+course of a PhD in CMSE.  University policy allows for up to 9 credits of graduate-level coursework
+to be transferred from another institution, and this transfer credit
+can be applied to the M.S. in
+CMSE as long as it is in topical areas relevant to the degree
+(determined by the CMSE graduate director).  The procedure for doing so is described below.
+
+
+\vspace{2mm}
+\noindent
+\textbf{Transferring graduate credits:}  MSU allows up to 9 credits of
+graduate
+coursework to be transferred from another institution.  A student
+wishing to transfer credits must provide an official transcript (which
+may already have been done as part of their application to MSU), and
+for each course they wish to transfer must provide a course syllabus
+including listing of textbooks, representative assignments (homework,
+exams, etc.), and a suggestion for the equivalent MSU course.  The
+CMSE graduate director, possibly in consultation with the Graduate
+Studies Committee, will determine if these courses are at an
+appropriate level for transfer as gradouate credits at MSU.  If so,
+they will initiate a request for awarding transfer credits to the
+student (with the appropriate grade).  In general, courses with a
+grade below 3.0 will not be transferred.
+
 
 \vspace{2mm}
 \noindent


### PR DESCRIPTION
Here are a bunch of changes to the grad handbook following the 2018-2019 academic year.  The primary changes are:

1.  Updated Master's degree section to clarify requirements regarding credits, GPA, 400-level course requirements, and minimum acceptable grades.
2.  Updated PhD degree section to clarify requirements regarding credits, minimum acceptable grades, and 400-level course requirements.
3.  Added text to Appendix A (Policy regarding prior graduate coursework) to explain how transferring graduate credits works and how credits for the Master's degree works.
4.  A variety of typo fixes.

For changes 1-3, these changes are all either clarifications based on student questions or requirements coming from Graduate School policies.  #4 primarily comes from things I noticed while working with individual graduate students.
